### PR TITLE
Add link to Devpost submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,6 @@ This system was built with the intentions of allowing entertainment venues (pubs
 3. Commit changes to the branch: `git add . && git commit -m "Present tense commit message"`
 4. Push the changes: `git push -u origin feature/feature-implementing`
 5. Submit a pull request
+
+# Devpost
+More information on the project [here](https://devpost.com/software/musicrowd)


### PR DESCRIPTION
The repo doesn't have any information on what the app looks like or what it can really do - so I added the link to the Devpost that has more info.

Also I was still getting charged for the Heroku app (l o l) so I downgraded the dyno from Hobby to Free.
The musicrowd.com link no longer works but you can reach the site from musicrowd.herokuapp.com (which we link to in the Devpost!)